### PR TITLE
Fix tabixHelper.sh to support presigned_urls with content-disposition…

### DIFF
--- a/tools/tabix_od/tabix_od.def
+++ b/tools/tabix_od/tabix_od.def
@@ -6,7 +6,7 @@ From: alpine:3.9
     tabixHelper.sh /usr/bin/tabixHelper
 
 %post
-    export HTSLIB_VERSION=1.9
+    export HTSLIB_VERSION=1.10.2
     apk update
     apk add build-base bash curl curl-dev bzip2-dev xz-dev xz-libs
     cd /build


### PR DESCRIPTION
….  This requires 1.10.2 tabix so that ##idx## can be appended to the vcf.gz URL