### PR TITLE
Add get chromosomes service (aka first line of vcf w/ actual variant data)

### DIFF
--- a/scripts/getChromosomes.sh
+++ b/scripts/getChromosomes.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tabix_od -l $1 $2

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,10 @@ router.post('/variantHeader', async (ctx) => {
     await handle(ctx, 'variantHeader.sh', [params.url, params.indexUrl]);
 });
 
+router.post('/getChromosomes', async (ctx) => {
+    const params = JSON.parse(ctx.request.body);
+    await handle(ctx, 'getChromosomes.sh', [params.url, params.indexUrl]);
+});
 
 router.get('/vcfReadDepth', async (ctx) => {
   await handle(ctx, 'vcfReadDepth.sh', [ctx.query.url]);

--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,7 @@ router.post('/variantHeader', async (ctx) => {
 
 router.post('/getChromosomes', async (ctx) => {
     const params = JSON.parse(ctx.request.body);
+    console.log(JSON.stringify(params, null, 2));
     await handle(ctx, 'getChromosomes.sh', [params.url, params.indexUrl]);
 });
 


### PR DESCRIPTION
This is used to verify the build selection (GRCh37/38) reported by the user and warn them if there's a discrepancy. Necessary because headers do not always contain this information or can report it incorrectly (in cases where files are lifted over to a new build). 

Really all this does is pull back the first line of the vcf with actual data (aka not header/column label). So it could be used for other checks besides chromosome format checks.