### PR TITLE
Set CORS Access-Control-Allow-Origin to '*'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -540,6 +540,7 @@ app
   .use(mount('/static', staticServer))
   .use(logger())
   .use(cors({
+    origin: '*',
     maxAge: 86400,
   }))
   .use(bodyParser({


### PR DESCRIPTION
There was a problem before because the koa cors module by default
returns whatever is in the Origin header. So the CDN was caching
the first origin used (in this case localhost:4026), and CORS
errors popped up once you tried it from another origin.