### PR TITLE
Add filtered alignment coverage

### DIFF
--- a/scripts/filteredReadsCount.sh
+++ b/scripts/filteredReadsCount.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+url=$1
+index_url=$2
+samtools_region=$3
+quality_cutoff=$4
+
+samtools_od view -q $quality_cutoff -c $url $samtools_region $index_url

--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,18 @@ router.post('/geneCoverage', async (ctx) => {
     await handle(ctx, 'geneCoverage.sh', args);
 });
 
+router.post('/filteredReadsCount', async (ctx) => {
+    const params = JSON.parse(ctx.request.body);
+    console.log(JSON.stringify(params, null, 2));
+   
+    const url = params.url;
+    const indexUrl = params.indexUrl;
+    const samtoolsRegion = params.regionStr;
+    const qualityCutoff = params.qualityCutoff;
+    const args = [url, indexUrl, samtoolsRegion, qualityCutoff];
+
+    await handle(ctx, 'filteredReadsCount.sh', args, { ignoreStderr: true });
+});
 
 router.get('/normalizeVariants', async (ctx) => {
   const vcfUrl = ctx.query.vcfUrl;


### PR DESCRIPTION
Our current alignmentCoverage script goes into a python program TDS wrote, specific for gene.iobio - this is a more generic endpoint that pulls back coverage counts directly and incorporates the ability to filter reads by MAPQ.