### PR TITLE
Pin ntlk version for phenotypeExtractor

### DIFF
--- a/tools/phenotypeExtractor/phenotypeExtractor.def
+++ b/tools/phenotypeExtractor/phenotypeExtractor.def
@@ -12,7 +12,7 @@ From: alpine:3.9
 
     apk add py-pip
 
-    pip install nltk
+    pip install nltk==3.4.5
 
     python -m nltk.downloader -d /usr/share/nltk_data wordnet
 


### PR DESCRIPTION
The latest version of ntlk appears to not work with python2.