### PR TITLE
Update genRegionsStr helper in index.js to accept custom delimiter

### DIFF
--- a/dev_tools/populate_static.sh
+++ b/dev_tools/populate_static.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 mkdir -p static/clinvar/GRCh37
-wget -P static/clinvar/GRCh37 https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz
-wget -P static/clinvar/GRCh37 https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi
+curl -o static/clinvar/GRCh37/clinvar.vcf.gz https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz
+curl -o static/clinvar/GRCh37/clinvar.vcf.gz.tbi https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/clinvar.vcf.gz.tbi
 mkdir -p static/clinvar/GRCh38
-wget -P static/clinvar/GRCh38 https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
-wget -P static/clinvar/GRCh38 https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi
+curl -o static/clinvar/GRCh38/clinvar.vcf.gz https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
+curl -o static/clinvar/GRCh38/clinvar.vcf.gz.tbi https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get -y install libfontconfig1
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node
 
 ARG gru_version=dev
-RUN git clone --depth 1 --branch ${gru_version} https://github.com/iobio/iobio-gru-backend
+RUN git clone --depth 1 --branch ${gru_version} https://github.com/anderspitman/iobio-gru-backend
 
 WORKDIR /iobio-gru-backend
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -29,6 +29,8 @@ RUN git clone --depth 1 --branch ${gru_version} https://github.com/anderspitman/
 
 WORKDIR /iobio-gru-backend
 
+RUN ["./dev_tools/populate_static.sh"]
+
 RUN ["npm", "install"]
 
 RUN ["mkdir", "tool_bin"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -73,6 +73,8 @@ COPY --from=anderspitman/iobio-vcf-stats-alive:latest /vcfStatsAlive tool_bin/
 
 COPY --from=anderspitman/iobio-vt:latest /vt/vt tool_bin/
 
+COPY --from=anderspitman/iobio-freebayes:latest /freebayes tool_bin/
+
 EXPOSE 9001
 
 #ENTRYPOINT ["node", "/iobio-gru-backend/src/index.js", "--tools-dir=/iobio-gru-backend/tool_bin"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,5 +1,5 @@
 #FROM ubuntu:18.04
-FROM ensemblorg/ensembl-vep:release_101.0
+FROM ensemblorg/ensembl-vep:release_103.0
 
 USER root
 WORKDIR /
@@ -81,3 +81,10 @@ EXPOSE 9001
 
 #ENTRYPOINT ["node", "/iobio-gru-backend/src/index.js", "--tools-dir=/iobio-gru-backend/tool_bin"]
 CMD ["node", "/iobio-gru-backend/src/index.js", "--tools-dir=/iobio-gru-backend/tool_bin"]
+
+# These directories are required for mounting writable singularity sandbox
+# images in the Utah CHPC environment, because of the directories that CHPC
+# automatically binds. Hopefully this won't be necessary in the future.
+RUN ["mkdir", "/uufs"]
+RUN ["mkdir", "/scratch"]
+RUN ["mkdir", "/ssd"]

--- a/scripts/alignmentCoverage.sh
+++ b/scripts/alignmentCoverage.sh
@@ -9,6 +9,9 @@ coverage_regions=$6
 quality_threshold=$7
 data_dir=$8
 
+tempDir=$(mktemp -d)
+cd $tempDir
+
 #if quality value provided, filter reads by mapq
 # otherwise just add binary flag
 view_opt="-b"
@@ -23,6 +26,8 @@ fi
 
 export REF_CACHE=$data_dir/md5_reference_cache/%2s/%2s/%s
 
-samtools-1.11 view $view_opt $data_opts $samtools_region | \
-    samtools-1.11 mpileup - | \
+samtools view $view_opt $data_opts $samtools_region | \
+    samtools mpileup - | \
     summarize_coverage $max_points $spanning_region $coverage_regions
+
+rm -rf $tempDir

--- a/scripts/annotateEnrichmentCounts.sh
+++ b/scripts/annotateEnrichmentCounts.sh
@@ -9,6 +9,9 @@ filterArgs=$6
 experStr=$7
 controlStr=$8
 
+tempDir=$(mktemp -d)
+cd $tempDir
+
 echo -e "$contigStr" > contigs.txt
 echo -e "$controlStr" > controlNames.txt
 
@@ -24,7 +27,12 @@ if [ -z "$filterArgs" ]; then
 	filterCmd=filterFunc
 fi
 
-tabix_od -h $vcfUrl $regionStr $tbiUrl | \
+tabixVcfArg=$vcfUrl
+if [ -n "${tbiUrl}" ]; then
+    tabixVcfArg="$vcfUrl##idx##$tbiUrl"
+fi
+
+tabix -h $tabixVcfArg $regionStr | \
     bcftools annotate -h contigs.txt - | \
     vt subset -s controlNames.txt - | \
     $filterCmd | \

--- a/scripts/annotateSomaticVariants.sh
+++ b/scripts/annotateSomaticVariants.sh
@@ -7,7 +7,7 @@ regions=$3
 somaticFilterPhrase=$4
 genomeBuildName=$5
 vepCacheDir=$6
-fastaPath=$7
+refFastaFile=$7
 
 runDir=$PWD
 tempDir=$(mktemp -d)
@@ -23,14 +23,14 @@ if [ ! -z "$somaticFilterPhrase" ]; then
 fi
 
 #Compose args
-vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
 vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
 echo -e "$regions" >> regions.txt
 
 #Do work
 bcftools view -s $selectedSamples $vcfUrl | \
     bcftools filter -t $regions - | \
-    bcftools norm -m - -w 10000 -f $fastaPath - | \
+    bcftools norm -m - -w 10000 -f $refFastaFile - | \
     $somFilterStage | \
     vep $vepArgs
 

--- a/scripts/annotateSomaticVariants.sh
+++ b/scripts/annotateSomaticVariants.sh
@@ -23,7 +23,8 @@ if [ ! -z "$somaticFilterPhrase" ]; then
 fi
 
 #Compose args
-vepArgs="--assembly $genomeBuildName --format vcf --allele_number --dir_cache $vepCacheDir"
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
 echo -e "$regions" >> regions.txt
 
 #Do work

--- a/scripts/annotateVariants.sh
+++ b/scripts/annotateVariants.sh
@@ -11,14 +11,13 @@ vepCacheDir=$8
 vepREVELFile=$9
 vepAF=${10}
 vepPluginDir=${11}
-isRefSeq=${12}
-hgvsNotation=${13}
-getRsId=${14}
-gnomadUrl=${15}
-gnomadRegionFileStr=${16}
-gnomadHeaderFile=${17}
-decompose=${18}
-gnomadRenameChr=${19}
+hgvsNotation=${12}
+getRsId=${13}
+gnomadUrl=${14}
+gnomadRegionFileStr=${15}
+gnomadHeaderFile=${16}
+decompose=${17}
+gnomadRenameChr=${18}
 
 # default optional stages to no-op
 subsetStage=cat
@@ -80,7 +79,7 @@ fi
 
 echo -e "$contigStr" > contigs.txt
 
-vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
 
 vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
 
@@ -92,20 +91,12 @@ if [ "$vepAF" == "true" ]; then
     vepArgs="$vepArgs --af --af_gnomad --af_esp --af_1kg --max_af"
 fi
 
-if [ "$isRefSeq" == "true" ]; then
-    vepArgs="$vepArgs --refseq"
-fi
-
 if [ "$hgvsNotation" == "true" ]; then
     vepArgs="$vepArgs --hgvs"
 fi
 
 if [ "$getRsId" == "true" ]; then
     vepArgs="$vepArgs --check_existing"
-fi
-
-if [ "$hgvsNotation" == "true" ] || [ "$getRsId" == "true" ] || [ "$isRefSeq" == "true" ]; then
-    vepArgs="$vepArgs --fasta $refFastaFile"
 fi
 
 tabixVcfArg=$vcfUrl

--- a/scripts/annotateVariants.sh
+++ b/scripts/annotateVariants.sh
@@ -80,11 +80,9 @@ fi
 
 echo -e "$contigStr" > contigs.txt
 
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
 
-# TODO: remove --dir_cache from vep Dockerfile since we're overriding it here.
-# Actually, move all the vep args into this script so they aren't split
-# between two locations.
-vepArgs="-i STDIN --format vcf --cache --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --assembly $genomeBuildName --format vcf --allele_number --dir_cache $vepCacheDir"
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
 
 if [ "$vepREVELFile" ]; then
     vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"

--- a/scripts/annotateVariants.sh
+++ b/scripts/annotateVariants.sh
@@ -84,7 +84,7 @@ echo -e "$contigStr" > contigs.txt
 # TODO: remove --dir_cache from vep Dockerfile since we're overriding it here.
 # Actually, move all the vep args into this script so they aren't split
 # between two locations.
-vepArgs="--assembly $genomeBuildName --format vcf --allele_number --dir_cache $vepCacheDir"
+vepArgs="-i STDIN --format vcf --cache --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --assembly $genomeBuildName --format vcf --allele_number --dir_cache $vepCacheDir"
 
 if [ "$vepREVELFile" ]; then
     vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"

--- a/scripts/checkBamBai.sh
+++ b/scripts/checkBamBai.sh
@@ -5,6 +5,9 @@ index_url=$2
 samtools_region=$3
 data_dir=$4
 
+tempDir=$(mktemp -d)
+cd $tempDir
+
 url_valid=$(curl -s $url | head -n 1 | tr '\0' '\n')
 index_valid=$(curl -s $index_url | head -n 1 | tr '\0' '\n')
 if [ -z "$url_valid" ] || [ -z "$index_valid" ]; 
@@ -21,4 +24,6 @@ export REF_CACHE=$data_dir/md5_reference_cache/%2s/%2s/%s
 
 echo "DEBUG - data_opts: $data_opts, REF_CACHE: $REF_CACHE" >&2
 
-samtools-1.11 view -H $data_opts $samtools_region | head -n 1
+samtools view -H $data_opts $samtools_region | head -n 1
+
+rm -rf $tempDir

--- a/scripts/clinvarCountsForGene.sh
+++ b/scripts/clinvarCountsForGene.sh
@@ -20,10 +20,10 @@ fi
 
 # Pipe into VEP if we want to return counts by VEP categories but haven't already annotated it
 if [ "$requiresVepService" = true ]; then
-    tabix_od -h $clinvarUrl $region | \
+    tabix -h $clinvarUrl $region | \
         vep $vepArgs | \
             knownVariants -r $region $binLengthArg $regionPartsArg $annotationModeArg
 else
-    tabix_od -h $clinvarUrl $region | \
+    tabix -h $clinvarUrl $region | \
         knownVariants -r $region $binLengthArg $regionPartsArg $annotationModeArg
 fi

--- a/scripts/freebayesJointCall.sh
+++ b/scripts/freebayesJointCall.sh
@@ -95,9 +95,9 @@ fi
 
 freebayesArgs="$freebayesArgs $extraArgs"
 
-vepArgs="-i STDIN --format vcf --cache --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --assembly $genomeBuildName --allele_number --dir_cache $vepCacheDir"
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
 
-vepArgs="$vepArgs --hgvs --check_existing --fasta $refFastaFile"
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number --hgvs --check_existing --fasta $refFastaFile"
 
 if [ "$vepREVELFile" ]; then
     vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"

--- a/scripts/freebayesJointCall.sh
+++ b/scripts/freebayesJointCall.sh
@@ -95,7 +95,9 @@ fi
 
 freebayesArgs="$freebayesArgs $extraArgs"
 
-vepArgs="--assembly $genomeBuildName --format vcf --dir_cache $vepCacheDir --allele_number --hgvs --check_existing --fasta $refFastaFile"
+vepArgs="-i STDIN --format vcf --cache --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --assembly $genomeBuildName --allele_number --dir_cache $vepCacheDir"
+
+vepArgs="$vepArgs --hgvs --check_existing --fasta $refFastaFile"
 
 if [ "$vepREVELFile" ]; then
     vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"

--- a/scripts/freebayesJointCall.sh
+++ b/scripts/freebayesJointCall.sh
@@ -34,8 +34,6 @@ echo -e "$samplesFileStr" > $samplesFile
 
 export REF_CACHE=$dataDir/md5_reference_cache/%2s/%2s/%s
 
-# TODO: using tabix instead of tabix_od would likely be faster
-
 freebayesArgs="-s $samplesFile"
 
 # split alignments by ','
@@ -60,7 +58,7 @@ IFS=' '
 tabixCommand=''
 if [ "$useSuggestedVariants" == "true" ]; then
     suggFile="sugg.vcf"
-    tabix_od -h $clinvarUrl $region | vt view -f "INFO.CLNSIG=~'5|4'" - > $suggFile
+    tabix -h $clinvarUrl $region | vt view -f "INFO.CLNSIG=~'5|4'" - > $suggFile
     freebayesArgs="$freebayesArgs -@ $suggFile"
 fi
 

--- a/scripts/freebayesJointCall.sh
+++ b/scripts/freebayesJointCall.sh
@@ -11,16 +11,15 @@ clinvarUrl=$6
 genomeBuildName=$7
 vepREVELFile=$8
 vepAF=$9
-isRefSeq=${10}
-samplesFileStr=${11}
-extraArgs=${12}
-vepCacheDir=${13}
-vepPluginDir=${14}
-gnomadUrl=${15}
-gnomadRegionFileStr=${16}
-gnomadHeaderFile=${17}
-decompose=${18}
-dataDir=${19}
+samplesFileStr=${10}
+extraArgs=${11}
+vepCacheDir=${12}
+vepPluginDir=${13}
+gnomadUrl=${14}
+gnomadRegionFileStr=${15}
+gnomadHeaderFile=${16}
+decompose=${17}
+dataDir=${18}
 
 runDir=$PWD
 tempDir=$(mktemp -d)
@@ -95,9 +94,9 @@ fi
 
 freebayesArgs="$freebayesArgs $extraArgs"
 
-vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4"
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
 
-vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number --hgvs --check_existing --fasta $refFastaFile"
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number --hgvs --check_existing"
 
 if [ "$vepREVELFile" ]; then
     vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"
@@ -106,11 +105,6 @@ fi
 if [ "$vepAF" == "true" ]; then
     vepArgs="$vepArgs --af --af_gnomad --af_esp --af_1kg --max_af"
 fi
-
-if [ "$isRefSeq" == "true" ]; then
-    vepArgs="$vepArgs --refseq"
-fi
-
 
 wait
 

--- a/scripts/getChromosomes.sh
+++ b/scripts/getChromosomes.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 
-tabix_od -l $1 $2
+vcfUrl=$1
+tbiUrl=$2
+
+tempDir=$(mktemp -d)
+cd $tempDir
+
+tabixVcfArg=$vcfUrl
+if [ -n "${tbiUrl}" ]; then
+    tabixVcfArg="$vcfUrl##idx##$tbiUrl"
+fi
+
+tabix -l $tabixVcfArg
+
+rm -rf $tempDir

--- a/scripts/vcfStatsStream.sh
+++ b/scripts/vcfStatsStream.sh
@@ -6,6 +6,11 @@ regionsStr=$3
 contigStr=$4
 sampleNamesStr=$5
 
+tabixVcfArg=$url
+if [ -n "${indexUrl}" ]; then
+    tabixVcfArg="$url##idx##$indexUrl"
+fi
+
 tempDir=$(mktemp -d)
 cd $tempDir
 
@@ -13,12 +18,12 @@ echo -e "$contigStr" > contigs.txt
 
 if [ "$sampleNamesStr" ]; then
         echo -e "$sampleNamesStr" > sample_names.txt
-        tabix_od -h $url $regionsStr $indexUrl | \
+        tabix -h $tabixVcfArg $regionsStr | \
                 bcftools annotate -h contigs.txt - | \
                 vt subset -s sample_names.txt - | \
                 vcfStatsAlive -u 1000 -Q 1000
 else
-        tabix_od -h $url $regionsStr $indexUrl | \
+        tabix -h $tabixVcfArg $regionsStr | \
                 bcftools annotate -h contigs.txt - | \
                 vcfStatsAlive -u 1000 -Q 1000
 fi

--- a/src/index.js
+++ b/src/index.js
@@ -370,11 +370,12 @@ router.post('/getIdColumns', async (ctx) => {
     const params = JSON.parse(ctx.request.body);
     console.log(JSON.stringify(params, null, 2));
 
-    const regionStr = genRegionsStr(params.regions);
+    const regionStr = genRegionsStr(params.regions, ",");
     const args = [
         params.vcfUrl, regionStr
     ];
 
+    console.log(regionStr);
     await handle(ctx, 'getIdColumns.sh', args, { ignoreStderr: true });
 });
 
@@ -440,7 +441,7 @@ function genRegionStr(region) {
   return region.refName + ':' + region.start + '-' + region.end;
 }
 
-function genRegionsStr(regions) {
+function genRegionsStr(regions, delim = " ") {
   let regionStr = "";
   for (const region of regions) {
 
@@ -450,10 +451,11 @@ function genRegionsStr(regions) {
       regionStr += ':' + region.start;
 
       if (region.end) {
-        regionStr += '-' + region.end + " ";
+        regionStr += '-' + region.end + delim;
       }
     }
   }
+  regionStr = regionStr.substring(0, regionStr.length - 1);
   return regionStr;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ router.use('/genomebuild', genomeBuildRouter.routes(), genomeBuildRouter.allowed
 router.use('/hpo', hpoRouter.routes(), hpoRouter.allowedMethods());
 
 router.get('/static/*', async (ctx) => {
-  const fsPath = dataPath(ctx.path);
+  const fsPath = path.join(__dirname, '..', ctx.path);
   await serveStatic(ctx, fsPath);
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,7 @@ router.post('/annotateVariants', async (ctx) => {
     const args = [
         params.vcfUrl, tbiUrl, regionStr, contigStr, vcfSampleNamesStr,
         refFastaFile, params.genomeBuildName, vepCacheDir, vepREVELFile, params.vepAF,
-        vepPluginDir, params.isRefSeq, params.hgvsNotation, params.getRsId, gnomadUrl,
+        vepPluginDir, params.hgvsNotation, params.getRsId, gnomadUrl,
         gnomadRegionStr, gnomadHeaderFile, params.decompose, gnomadRenameChr
 
     ];
@@ -297,7 +297,7 @@ router.post('/freebayesJointCall', async (ctx) => {
   const args = [
     alignments, indices, region, refFastaFile, useSuggestedVariants,
     params.clinvarUrl, params.genomeBuildName, vepREVELFile, params.vepAF,
-    params.isRefSeq, samplesFileStr, extraArgs, vepCacheDir, vepPluginDir,
+    samplesFileStr, extraArgs, vepCacheDir, vepPluginDir,
     gnomadUrl, gnomadRegionStr, gnomadHeaderFile, decompose, dataPath(''),
   ];
 

--- a/tools/freebayes/Dockerfile
+++ b/tools/freebayes/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get -y install curl
+
+RUN curl -L https://github.com/freebayes/freebayes/releases/download/v1.3.4/freebayes-1.3.4-linux-static-AMD64.gz | gunzip > freebayes && chmod +x freebayes
+
+ENTRYPOINT ["/freebayes"]

--- a/tools/vcfReadDepther/vcfReadDeptherHelper.sh
+++ b/tools/vcfReadDepther/vcfReadDeptherHelper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 input=stdin
 args=""

--- a/tuplates_config.json
+++ b/tuplates_config.json
@@ -1,4 +1,4 @@
 {
-  "exclude": ["node_modules"],
-  "extensions": [".py", ".js", ".json"]
+  "exclude": ["node_modules", "tool_bin"],
+  "extensions": ["py", "js", "json"]
 }


### PR DESCRIPTION
Bcftools view would not pull back multiple regions when I used spaces as delimiter for regions argument with >1 region. Just made an optional parameter for genRegionsStr so it could accept custom delimiter. Still defaults to spaces.