### PR TITLE
Speed up annotate variants

### DIFF
--- a/scripts/annotateVariants.sh
+++ b/scripts/annotateVariants.sh
@@ -72,12 +72,14 @@ if [ "$gnomadUrl" ]; then
 
         tabix my.vcf.gz $region | cut -f 1-2 > variant_regions.txt
 
-        if (($(wc -l <"variant_regions.txt") >= 1000)); then
+        # For big genes like DMD, specifying the exact positions speeds up bcftools 
+        # annotate from 2 minutes to a few seconds.
+        # We only want to use exact positions of variants when there are under a few 
+        # hundred variants; otherwise, bcftools slows down terribly. 
+        if (($(wc -l <"variant_regions.txt") >= 200)); then
             regions_file=gnomad_regions.txt
-            echo 'Too many variants, using gnomad_regions.txt' >&2
         else
             regions_file=variant_regions.txt
-            echo 'Using variant_regions.txt' >&2
         fi
 
         # Add the gnomAD INFO fields to the input vcf


### PR DESCRIPTION
This modification to annotateVariants.sh will speed up annotation on large genes like DMD.  This is accomplished by specifying the exact positions of the variants in the regions file.  We only do this when we have less than 200 variants.  Any more than that, and specifying the exact positions makes bcftools run very slowly.