### PR TITLE
Fix slowdown in annotate variants for WGS variant files

### DIFF
--- a/scripts/annotateVariants.sh
+++ b/scripts/annotateVariants.sh
@@ -74,9 +74,9 @@ if [ "$gnomadUrl" ]; then
 
         # For big genes like DMD, specifying the exact positions speeds up bcftools 
         # annotate from 2 minutes to a few seconds.
-        # We only want to use exact positions of variants when there are under a few 
-        # hundred variants; otherwise, bcftools slows down terribly. 
-        if (($(wc -l <"variant_regions.txt") >= 200)); then
+        # We only want to use exact positions of variants when there are under 
+        # 20 variants; otherwise, bcftools slows down terribly. 
+        if (($(wc -l <"variant_regions.txt") >= 20)); then
             regions_file=gnomad_regions.txt
         else
             regions_file=variant_regions.txt


### PR DESCRIPTION
Only use exact variant positions in regions file for bcftools annotate for up to 20 variants.  When there are more than 20 variants, we start to see diminishing response time.