### PR TITLE
Annotate vcf with gnomAD annotations using vcfanno instead of bcftools

### DIFF
--- a/scripts/annotateVariantsV2.sh
+++ b/scripts/annotateVariantsV2.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+vcfUrl=$1
+tbiUrl=$2
+region=$3
+contigStr=$4
+vcfSampleNamesStr=$5
+refFastaFile=$6
+genomeBuildName=$7
+vepCacheDir=$8
+vepREVELFile=$9
+vepAF=${10}
+vepPluginDir=${11}
+hgvsNotation=${12}
+getRsId=${13}
+gnomadMergeAnnots=${14}
+decompose=${15}
+
+# default optional stages to no-op
+subsetStage=cat
+gnomadAnnotStage=cat
+decomposeStage=cat
+
+runDir=$PWD
+tempDir=$(mktemp -d)
+cd $tempDir
+
+if [ "$vcfSampleNamesStr" ]; then
+    echo -e "$vcfSampleNamesStr" > samples.txt
+
+    function subsetFunc {
+        vt subset -s samples.txt -
+    }
+
+    subsetStage=subsetFunc
+fi
+
+
+if [ "$decompose" == "true" ]; then
+    function decomposeFunc {
+        vt decompose -s  -
+    }
+
+    decomposeStage=decomposeFunc
+fi
+
+if [ "$gnomadMergeAnnots" ]; then
+    
+    if [ "$genomeBuildName" == "GRCh38" ]; then
+        toml="/data/gnomad/vcfanno_gnomad_3.1_grch38.toml"
+    else
+    	toml="/data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
+    fi
+
+    function gnomadAnnotFunc {
+        # Add the gnomAD INFO fields to the input vcf
+        vcfanno $toml /dev/stdin
+    }
+
+    gnomadAnnotStage=gnomadAnnotFunc
+fi
+
+
+echo -e "$contigStr" > contigs.txt
+
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
+
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
+
+if [ "$vepREVELFile" ]; then
+    vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"
+fi
+
+if [ "$vepAF" == "true" ]; then
+    vepArgs="$vepArgs --af --af_gnomad --af_esp --af_1kg --max_af"
+fi
+
+if [ "$hgvsNotation" == "true" ]; then
+    vepArgs="$vepArgs --hgvs"
+fi
+
+if [ "$getRsId" == "true" ]; then
+    vepArgs="$vepArgs --check_existing"
+fi
+
+tabixVcfArg=$vcfUrl
+if [ -n "${tbiUrl}" ]; then
+    tabixVcfArg="$vcfUrl##idx##$tbiUrl"
+fi
+
+tabix -h $tabixVcfArg $region | \
+    bcftools annotate -h contigs.txt - | \
+    $subsetStage | \
+    $decomposeStage | \
+    vt normalize -n -r $refFastaFile - | \
+    vep $vepArgs | \
+    $gnomadAnnotStage
+
+#echo $tempDir
+rm -rf $tempDir
+cd $runDir

--- a/scripts/getClinvarVariantsV2.sh
+++ b/scripts/getClinvarVariantsV2.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+vcfUrl=$1
+tbiUrl=$2
+region=$3
+contigStr=$4
+refFastaFile=$5
+genomeBuildName=$6
+gnomadMergeAnnots=$7
+pathoFilterPhrase=${8}
+
+runDir=$PWD
+tempDir=$(mktemp -d)
+cd $tempDir
+
+echo -e "$contigStr" > contigs.txt
+
+tabixVcfArg=$vcfUrl
+if [ -n "${tbiUrl}" ]; then
+    tabixVcfArg="$vcfUrl##idx##$tbiUrl"
+fi
+
+#optional gnomad stage
+gnomadAnnotStage=cat
+if [ "$gnomadMergeAnnots" ]; then
+    
+    if [ "$genomeBuildName" == "GRCh38" ]; then
+        toml="/data/gnomad/vcfanno_gnomad_3.1_grch38.toml"
+    fi
+    	toml="/data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
+
+    function gnomadAnnotFunc {
+        # Add the gnomAD INFO fields to the input vcf
+        vcfanno $toml /dev/stdin
+    }
+
+    gnomadAnnotStage=gnomadAnnotFunc
+fi
+
+tabix -h $tabixVcfArg $region | \
+    bcftools annotate -h contigs.txt - | \
+    vt normalize -n -r $refFastaFile - | \
+    bcftools filter -i $pathoFilterPhrase - | \
+    $gnomadAnnotStage
+
+#echo $tempDir
+rm -rf $tempDir
+cd $runDir

--- a/src/index.js
+++ b/src/index.js
@@ -208,6 +208,26 @@ router.post('/getClinvarVariants', async (ctx) => {
     await handle(ctx, 'getClinvarVariants.sh', args, { ignoreStderr: true });
 });
 
+router.post('/getClinvarVariantsV2', async (ctx) => {
+    const params = JSON.parse(ctx.request.body);
+    console.log(JSON.stringify(params, null, 2));
+
+    const tbiUrl = params.tbiUrl ? params.tbiUrl : '';
+    const contigStr = genContigFileStr(params.refNames);
+    const regionStr = genRegionsStr(params.regions);
+    const refFastaFile = dataPath(params.refFastaFile);
+    const gnomadMergeAnnots = params.gnomadMergeAnnots ? params.gnomadMergeAnnots : '';
+
+    const args = [
+        params.vcfUrl, tbiUrl, regionStr, contigStr, refFastaFile, 
+        params.genomeBuildName, gnomadMergeAnnots, params.clinSigFilterPhrase
+    ];
+
+    console.log(args);
+   
+    await handle(ctx, 'getClinvarVariants.sh', args, { ignoreStderr: true });
+});
+
 router.post('/annotateVariants', async (ctx) => {
 
     const params = JSON.parse(ctx.request.body);
@@ -240,6 +260,33 @@ router.post('/annotateVariants', async (ctx) => {
     await handle(ctx, 'annotateVariants.sh', args, { ignoreStderr: true });
 });
 
+
+router.post('/annotateVariantsV2', async (ctx) => {
+
+    const params = JSON.parse(ctx.request.body);
+    console.log(JSON.stringify(params, null, 2));
+
+    const tbiUrl = params.tbiUrl ? params.tbiUrl : '';
+    const contigStr = genContigFileStr(params.refNames);
+    const regionStr = genRegionsStr(params.regions);
+    const vcfSampleNamesStr = params.vcfSampleNames.join("\n");
+    const refFastaFile = dataPath(params.refFastaFile);
+    const vepCacheDir = dataPath('vep-cache');
+    const vepREVELFile = dataPath(params.vepREVELFile);
+    const vepPluginDir = dataPath('vep-cache/Plugins');
+    const gnomadMergeAnnots = params.gnomadMergeAnnots ? params.gnomadMergeAnnots : '';
+
+    const args = [
+        params.vcfUrl, tbiUrl, regionStr, contigStr, vcfSampleNamesStr,
+        refFastaFile, params.genomeBuildName, vepCacheDir, vepREVELFile, params.vepAF,
+        vepPluginDir, params.hgvsNotation, params.getRsId, gnomadMergeAnnots, 
+        params.decompose
+
+    ];
+
+    console.log(args);
+    await handle(ctx, 'annotateVariantsV2.sh', args, { ignoreStderr: true });
+});
 router.post('/annotateEnrichmentCounts', async (ctx) => {
     const params = JSON.parse(ctx.request.body);
     console.log(JSON.stringify(params, null, 2));


### PR DESCRIPTION
This is a new PR, based on the refreshed dev branch which contains the vcfanno dependencies.