### PR TITLE
Fix annotate variants v2 datadir

### DIFF
--- a/scripts/annotateVariantsV2.sh
+++ b/scripts/annotateVariantsV2.sh
@@ -15,6 +15,7 @@ hgvsNotation=${12}
 getRsId=${13}
 gnomadMergeAnnots=${14}
 decompose=${15}
+dataDir=${16}
 
 # default optional stages to no-op
 subsetStage=cat
@@ -47,9 +48,9 @@ fi
 if [ "$gnomadMergeAnnots" ]; then
     
     if [ "$genomeBuildName" == "GRCh38" ]; then
-        toml="/data/gnomad/vcfanno_gnomad_3.1_grch38.toml"
+        toml="$dataDir/gnomad/vcfanno_gnomad_3.1_grch38.toml"
     else
-    	toml="/data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
+    	toml="$dataDir/gnomad/vcfanno_gnomad_2.1_grch37.toml"
     fi
 
     function gnomadAnnotFunc {

--- a/scripts/getClinvarVariantsV2.sh
+++ b/scripts/getClinvarVariantsV2.sh
@@ -8,6 +8,7 @@ refFastaFile=$5
 genomeBuildName=$6
 gnomadMergeAnnots=$7
 pathoFilterPhrase=${8}
+dataDir=${9}
 
 runDir=$PWD
 tempDir=$(mktemp -d)
@@ -25,9 +26,9 @@ gnomadAnnotStage=cat
 if [ "$gnomadMergeAnnots" ]; then
     
     if [ "$genomeBuildName" == "GRCh38" ]; then
-        toml="/data/gnomad/vcfanno_gnomad_3.1_grch38.toml"
+        toml="$dataDir/gnomad/vcfanno_gnomad_3.1_grch38.toml"
     fi
-    	toml="/data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
+    	toml="$dataDir/gnomad/vcfanno_gnomad_2.1_grch37.toml"
 
     function gnomadAnnotFunc {
         # Add the gnomAD INFO fields to the input vcf

--- a/src/index.js
+++ b/src/index.js
@@ -211,9 +211,12 @@ router.post('/getClinvarVariantsV2', async (ctx) => {
     const refFastaFile = dataPath(params.refFastaFile);
     const gnomadMergeAnnots = params.gnomadMergeAnnots ? params.gnomadMergeAnnots : '';
 
+    const dataDir = dataPath('');
+    
     const args = [
         params.vcfUrl, tbiUrl, regionStr, contigStr, refFastaFile, 
-        params.genomeBuildName, gnomadMergeAnnots, params.clinSigFilterPhrase
+        params.genomeBuildName, gnomadMergeAnnots, params.clinSigFilterPhrase,
+        dataDir
     ];
 
     await handle(ctx, 'getClinvarVariantsV2.sh', args, { ignoreStderr: true });
@@ -264,11 +267,13 @@ router.post('/annotateVariantsV2', async (ctx) => {
     const vepPluginDir = dataPath('vep-cache/Plugins');
     const gnomadMergeAnnots = params.gnomadMergeAnnots ? params.gnomadMergeAnnots : '';
 
+    const dataDir = dataPath('');
+  
     const args = [
         params.vcfUrl, tbiUrl, regionStr, contigStr, vcfSampleNamesStr,
         refFastaFile, params.genomeBuildName, vepCacheDir, vepREVELFile, params.vepAF,
         vepPluginDir, params.hgvsNotation, params.getRsId, gnomadMergeAnnots, 
-        params.decompose
+        params.decompose, dataDir
 
     ];
 


### PR DESCRIPTION
The data directory in annotateVariantsV2.sh and getClinvarVariantsV2.sh for the gnomad toml file cannnot be hard-coded. Pass data dir into scripts so to work with Nebula container