### PR TITLE
Annotate somatic variants v2

### DIFF
--- a/dev_tools/populate_static.sh
+++ b/dev_tools/populate_static.sh
@@ -8,3 +8,8 @@ curl --fail -o static/clinvar/GRCh37/clinvar.vcf.gz.tbi https://ftp.ncbi.nlm.nih
 mkdir -p static/clinvar/GRCh38
 curl --fail -o static/clinvar/GRCh38/clinvar.vcf.gz https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/weekly/clinvar_20220320.vcf.gz
 curl --fail -o static/clinvar/GRCh38/clinvar.vcf.gz.tbi https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/weekly/clinvar_20220320.vcf.gz.tbi
+
+mkdir -p static/ensembl/GRCh37
+curl --fail -o static/ensembl/GRCh37/geneSet37.gff3.gz ftp://ftp.ensembl.org/pub/grch37/current/gff3/homo_sapiens/Homo_sapiens.GRCh37.87.chr.gff3.gz
+mkdir -p static/ensembl/GRCh38
+curl --fail ftp://ftp.ensembl.org/pub/current_gff3/homo_sapiens/Homo_sapiens.GRCh38.107.chr.gff3.gz | gzip -d - | perl -pe 's/^([0-9]+|[X]|[Y]|[M])/chr$1/' - | gzip - >> static/ensembl/GRCh38/geneSet38.gff3.gz 

--- a/scripts/annotateSomaticVariantsBcsq.sh
+++ b/scripts/annotateSomaticVariantsBcsq.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 #SJG updated Sept2022
-#set -euo pipefail
+set -euo pipefail
 
 vcfUrl=$1
 selectedSamples=$2
 regions=$3
-genomeBuild=$4
-somaticFilterPhrase=$5
-refFastaFile=$6
-gffFile=$7
+somaticFilterPhrase=$4
+refFastaFile=$5
+gffFile=$6
 
 runDir=$PWD
 tempDir=$(mktemp -d)
@@ -35,20 +34,24 @@ fi
 echo -e "$regions" >> regions.txt
 
 #remove prefix from gff file
-if [ "$genomeBuild" == "GRCh38" ]; then
-    cat $gffFile | gzip -d - | \
-    perl -pe 's/^([0-9]+|[X]|[Y]|[M])/chr$1/' - | \
-    gzip - >> noPrefix.gff3.gz
-else
-    cat $gffFile >> noPrefix.gff3.gz
-fi
+#gffFile="/iobio-gru-backend/static/ensembl/GRCh38/geneSet38.gff3.gz"
+#if [ "$genomeBuild" == "GRCh38" ]; then
+#    cat $gffFile | gzip -d - | \
+#    perl -pe 's/^([0-9]+|[X]|[Y]|[M])/chr$1/' - | \
+#    gzip - >> noPrefix.gff3.gz
+#    gffFile="/iobio-gru-backend/static/ensembl/GRCh37/geneSet37.gff3.gz"
+#else
+#    cat $gffFile >> noPrefix.gff3.gz
+#fi
+
+#cat $gffFile | gzip -d -
 
 #Do work
 bcftools view -s $selectedSamples $vcfUrl | \
     $regionFilterStage | \
     bcftools norm -m - -w 10000 -f $refFastaFile - | \
     $somFilterStage | \
-    bcftools csq -f $refFastaFile -g noPrefix.gff3.gz - -Ov -l
+    bcftools csq -f $refFastaFile -g $gffFile - -Ov -l
 
 rm -rf $tempDir
 cd $runDir

--- a/scripts/annotateSomaticVariantsBcsq.sh
+++ b/scripts/annotateSomaticVariantsBcsq.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#SJG updated Jun2020
+#SJG updated Aug2022
+set -euo pipefail
 
 vcfUrl=$1
 selectedSamples=$2
 regions=$3
 somaticFilterPhrase=$4
-genomeBuildName=$5
-vepCacheDir=$6
-refFastaFile=$7
+refFastaFile=$5
+gffFile=$6
 
 runDir=$PWD
 tempDir=$(mktemp -d)
@@ -31,9 +31,6 @@ if [ ! -z "$somaticFilterPhrase" ]; then
     somFilterStage=somFilterFunc
 fi
 
-#Compose args
-vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
-vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
 echo -e "$regions" >> regions.txt
 
 #Do work
@@ -41,7 +38,7 @@ bcftools view -s $selectedSamples $vcfUrl | \
     $regionFilterStage | \
     bcftools norm -m - -w 10000 -f $refFastaFile - | \
     $somFilterStage | \
-    vep $vepArgs
+    bcftools csq -f $refFastaFile -g $gffFile - -Ov -pa
 
 rm -rf $tempDir
 cd $runDir

--- a/scripts/annotateSomaticVariantsVep.sh
+++ b/scripts/annotateSomaticVariantsVep.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#SJG updated Jun2020
+set -euo pipefail
+
+vcfUrl=$1
+selectedSamples=$2
+regions=$3
+somaticFilterPhrase=$4
+genomeBuildName=$5
+vepCacheDir=$6
+refFastaFile=$7
+
+runDir=$PWD
+tempDir=$(mktemp -d)
+cd $tempDir
+
+# Add region filter stage if we have regions
+regionFilterStage=cat
+if [ ! -z "$regions" ]; then
+    function regionFilterFunc {
+        bcftools filter -t $regions -
+    }
+    regionFilterStage=regionFilterFunc
+fi
+
+#Add somatic filter stage if we have a filter
+somFilterStage=cat
+if [ ! -z "$somaticFilterPhrase" ]; then
+    function somFilterFunc {
+        bcftools filter -i $somaticFilterPhrase -
+    }
+    somFilterStage=somFilterFunc
+fi
+
+#Compose args
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
+echo -e "$regions" >> regions.txt
+
+#Do work
+bcftools view -s $selectedSamples $vcfUrl | \
+    $regionFilterStage | \
+    bcftools norm -m - -w 10000 -f $refFastaFile - | \
+    $somFilterStage | \
+    vep $vepArgs
+
+rm -rf $tempDir
+cd $runDir
+

--- a/src/index.js
+++ b/src/index.js
@@ -314,14 +314,14 @@ router.post('/annotateSomaticVariantsBcsq', async (ctx) => {
   const params = JSON.parse(ctx.request.body);
 
   let refFastaFile = dataPath('references/GRCh37/human_g1k_v37_decoy_phix.fasta');
-  let gffFile = dataPath('ensembl/GRCh37/Homo_sapiens.GRCh37.87.gff3.gz');
+  let gffFile = '/iobio-gru-backend/static/ensembl/GRCh37/geneSet37.gff3.gz';
 
   if (params.genomeBuildName === 'GRCh38') {
     refFastaFile = dataPath('references/GRCh38/human_g1k_v38_decoy_phix.fasta');
-    gffFile = dataPath('ensembl/GRCh38/Homo_sapiens.GRCh38.107.chr.gff3.gz');
+    gffFile = '/iobio-gru-backend/static/ensembl/GRCh38/geneSet38.gff3.gz';
   }
 
-  const args = [params.vcfUrl, params.selectedSamplesStr, params.geneRegionsStr, params.genomeBuildName, params.somaticFilterPhrase, refFastaFile, gffFile];
+  const args = [params.vcfUrl, params.selectedSamplesStr, params.geneRegionsStr, params.somaticFilterPhrase, refFastaFile, gffFile];
   
   await handle(ctx, 'annotateSomaticVariantsBcsq.sh', args, { ignoreStderr: true });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -318,12 +318,10 @@ router.post('/annotateSomaticVariantsBcsq', async (ctx) => {
 
   if (params.genomeBuildName === 'GRCh38') {
     refFastaFile = dataPath('references/GRCh38/human_g1k_v38_decoy_phix.fasta');
-
-    // NOTE: this 38 file needs to be amended when updated!! (perl -pe 's/^([0-9]+)/chr$1/')
     gffFile = dataPath('ensembl/GRCh38/Homo_sapiens.GRCh38.107.chr.gff3.gz');
   }
 
-  const args = [params.vcfUrl, params.selectedSamplesStr, params.geneRegionsStr, params.somaticFilterPhrase, refFastaFile, gffFile];
+  const args = [params.vcfUrl, params.selectedSamplesStr, params.geneRegionsStr, params.genomeBuildName, params.somaticFilterPhrase, refFastaFile, gffFile];
   
   await handle(ctx, 'annotateSomaticVariantsBcsq.sh', args, { ignoreStderr: true });
 });


### PR DESCRIPTION
Added new script `annotateSomaticVariantsBcsq.sh` that uses bcftools csq instead of VEP. Still want to keep the old version, so renamed original `annotateSomaticVariants.sh`-> `annotateSomaticVariantsVep.sh`. The original script may still be used by the production oncogene front-end (an option for power users). 

This PR requires two new files be added to data directory bound to the gru container at `{data}/ensembl/GRCh37/Homo_sapiens.GRCh37.87.gff3.gz` and `{data}/ensembl/GRCh38/Homo_sapiens.GRCh38.107.chr.gff3.gz`. These files will be updated within their respective directories occasionally, as new version are released. Future versions are accessible via Ensembl FTP, and current versions are available at `/uufs/chpc.utah.edu/common/HIPAA/u0746015/gru/steph/data/ensembl/GRCh*/`. 

Neither file needs to be altered prior to putting in the data directory (specifically noting this because in the last closed PR, the GRCh38 file needed to have the 'chr' delimiter added prior via a perl command that is now rolled in to the script- despite the Ensembl file name having the phrase `chr` in it). 