### PR TITLE
Expand gene2pheno service to show disorders associated with a gene

### DIFF
--- a/src/gene2pheno.js
+++ b/src/gene2pheno.js
@@ -5,7 +5,7 @@ function getDb() {
   if (!_db) {
     const sqlite3 = require('sqlite3').verbose();
     const { dataPath } = require('./utils.js');
-    _db = new sqlite3.Database(dataPath('gene2pheno/hpo_gene_to_phenotype.db'));
+    _db = new sqlite3.Database(dataPath('gene2pheno/gene_to_phenotype.db'));
   }
   return _db;
 }

--- a/src/gene2pheno.js
+++ b/src/gene2pheno.js
@@ -33,7 +33,7 @@ function promiseGetGeneDisorders(db, gene_name) {
 const router = new Router();
 
 router.get('/api/gene/:gene', async (ctx) => {
-  var sqlString = "SELECT * from gene_to_phenotype where entrez_gene_symbol=\""+ctx.params.gene+"\" ";
+  var sqlString = "SELECT * from gene_to_phenotype where gene_symbol=\""+ctx.params.gene+"\" ";
 
   const db = getDb();
 
@@ -46,7 +46,11 @@ router.get('/api/gene/:gene', async (ctx) => {
       var phenotypes = [];
       if (rows != null && rows.length > 0) {
         for (var i = 0; i < rows.length; i++) {
-          phenotype_data = rows[i];           
+          phenotype_data = rows[i];  
+          phenotype_data['entrez_gene_symbol'] = phenotype_data['gene_symbol']         
+          phenotype_data['entrez_gene_id'] = phenotype_data['ncbi_gene_id']         
+          phenotype_data['hpo_term_id'] = phenotype_data['hpo_id']         
+          phenotype_data['hpo_term_name'] = phenotype_data['hpo_name']         
           phenotypes.push(phenotype_data);
         }
       } 
@@ -63,7 +67,7 @@ router.get('/api/gene/:gene', async (ctx) => {
 
 // v2 (cacheable) endpoints
 router.get('/:gene', async (ctx) => {
-  var sqlString = "SELECT * from gene_to_phenotype where entrez_gene_symbol=\""+ctx.params.gene+"\" ";
+  var sqlString = "SELECT * from gene_to_phenotype where gene_symbol=\""+ctx.params.gene+"\" ";
 
   const db = getDb();
 
@@ -76,7 +80,12 @@ router.get('/:gene', async (ctx) => {
       var phenotypes = [];
       if (rows != null && rows.length > 0) {
         for (var i = 0; i < rows.length; i++) {
-          phenotype_data = rows[i];           
+          phenotype_data = rows[i];    
+          phenotype_data['entrez_gene_symbol'] = phenotype_data['gene_symbol']         
+          phenotype_data['entrez_gene_id'] = phenotype_data['ncbi_gene_id']         
+          phenotype_data['hpo_term_id'] = phenotype_data['hpo_id']         
+          phenotype_data['hpo_term_name'] = phenotype_data['hpo_name']         
+                 
           phenotypes.push(phenotype_data);
         }
       } 
@@ -90,6 +99,7 @@ router.get('/:gene', async (ctx) => {
     });
   });
 });
+
 
 // v3 In addition to returning associated phenotypes, this endpoint also returns 
 // associated disorders for a gene.
@@ -135,6 +145,7 @@ router.get('/associations/:gene', async (ctx) => {
     });
   });
 });
+
 
 
 module.exports = router;

--- a/src/gene2pheno.js
+++ b/src/gene2pheno.js
@@ -10,6 +10,26 @@ function getDb() {
   return _db;
 }
 
+function promiseGetGeneDisorders(db, gene_name) {
+  var sqlString = "SELECT * from gene_to_disorder where gene_symbol=\""+gene_name+"\" ";
+  return new Promise((resolve, reject) => {
+    db.all(sqlString,function(err,rows){ 
+
+      if (err) reject(err);
+
+      var disorder_data = {};
+      var disorders = [];
+      if (rows != null && rows.length > 0) {
+        for (var i = 0; i < rows.length; i++) {
+          disorder_data = rows[i];           
+          disorders.push(disorder_data);
+        }
+      } 
+      resolve(disorders)
+    })
+  })
+}
+
 const router = new Router();
 
 router.get('/api/gene/:gene', async (ctx) => {
@@ -67,6 +87,51 @@ router.get('/:gene', async (ctx) => {
       ctx.body = JSON.stringify(phenotypes);
 
       resolve();
+    });
+  });
+});
+
+// v3 In addition to returning associated phenotypes, this endpoint also returns 
+// associated disorders for a gene.
+router.get('/associations/:gene', async (ctx) => {
+  var sqlString = "SELECT * from gene_to_phenotype where gene_symbol=\""+ctx.params.gene+"\" ";
+
+  const db = getDb();
+
+  return new Promise((resolve, reject) => {
+    db.all(sqlString,function(err,rows){ 
+
+      if (err) reject(err);
+
+      var phenotype_data = {};
+      var phenotypes = [];
+      if (rows != null && rows.length > 0) {
+        for (var i = 0; i < rows.length; i++) {
+          phenotype_data = rows[i];           
+          phenotypes.push(phenotype_data);
+        }
+      } 
+
+      promiseGetGeneDisorders(db, ctx.params.gene)
+      .then(function(disorders) {
+
+        let associations = {'gene': ctx.params.gene, 
+                            'phenotypes': phenotypes, 
+                            'disorders': disorders}
+      
+        ctx.set('Content-Type', 'application/json');
+        ctx.set('Charset', 'utf-8');
+        ctx.set('Cache-Control', 'public,max-age=84600')
+        ctx.body = JSON.stringify(associations);
+
+        resolve();
+
+      })
+      .catch(function(error) {
+        reject(error)
+      })
+
+
     });
   });
 });


### PR DESCRIPTION
- The GitHub repo https://github.com/iobio/gene_phenotype_associations contains the script to populate a fresh copy of the sqlite3 database from HPO gene_to_phenotypes.txt. The file format has changed slightly and the table columns reflect these new names. For backward compatibility, the JSON returned will contain fields for the old and new names.
    -  hpo_term_id -> hpo_id
    - hpo_term_name -> hpo_name
    - entrez_gene_symbol -> gene_symbol
    - entrez_gene_id -> ncbi_gene_id

- The sqlite3 database has been renamed from `hpo_gene_to_phenotype.db` to `gene_to_phenotype.db` to reflect its expanded schema, which now contains gene to disorder associations that are populated from an XML file provided by Orphanet and gene2map.txt provided from OMIM.
    - Copy  `/ssd/gru/tony/data/gene2pheno/gene_to_phenotype.db `on Mosaic the gru data
    - Remove `hpo_gene_to_phenotype.db` from the gru data
