### PR TITLE
Update bcftools view script

### DIFF
--- a/scripts/bcftoolsView.sh
+++ b/scripts/bcftoolsView.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SJG updated Aug2023
+# General purpose record retrieval script
+# Can add further functionality as needed in future
+set -euo pipefail
+
+vcfUrl=$1
+region=$2
+lineNumber=$3
+
+regionArg=$region
+if [ ! -z "$region" ]; then
+    regionArg="-r $region"
+fi
+
+headStage=cat
+if [ ! -z "$lineNumber" ]; then
+    function headFunc {
+        head -n $lineNumber
+    }
+    headStage=headFunc
+fi
+
+bcftools view $regionArg $vcfUrl | \
+    headStage

--- a/scripts/bcftoolsView.sh
+++ b/scripts/bcftoolsView.sh
@@ -2,17 +2,15 @@
 # SJG updated Aug2023
 # General purpose record retrieval script
 # Can add further functionality as needed in future
-set -euo pipefail
-
+set -uo pipefail
 vcfUrl=$1
 region=$2
 numLines=$3
 
-regionArg=$region
+regionArg=$""
 if [ ! -z "$region" ]; then
     regionArg="-r $region"
 fi
-
 # Optional retrieve n lines without header
 headStage=cat
 headerArg=$""
@@ -24,5 +22,7 @@ if [ ! -z "$numLines" ]; then
     headerArg="-H" #Don't include header
 fi
 
-bcftools view $headerArg $regionArg $vcfUrl | \
-    $headStage
+# Incantation taken from here: https://unix.stackexchange.com/a/580119
+# because apparently bcftools doesn't handly SIGPIPE gracefully
+(bcftools view $headerArg $regionArg $vcfUrl; e="$?"; [ "$e" -eq 141 ] && exit 0; exit "$e") | \
+        $headStage

--- a/scripts/bcftoolsView.sh
+++ b/scripts/bcftoolsView.sh
@@ -13,6 +13,7 @@ if [ ! -z "$region" ]; then
     regionArg="-r $region"
 fi
 
+# Optional retrieve n lines without header
 headStage=cat
 headerArg=$""
 if [ ! -z "$numLines" ]; then

--- a/scripts/bcftoolsView.sh
+++ b/scripts/bcftoolsView.sh
@@ -14,12 +14,14 @@ if [ ! -z "$region" ]; then
 fi
 
 headStage=cat
+headerArg=$""
 if [ ! -z "$lineNumber" ]; then
     function headFunc {
         head -n $lineNumber
     }
     headStage=headFunc
+    headerArg="-H" #Don't include header
 fi
 
-bcftools view $regionArg $vcfUrl | \
+bcftools view $headerArg $regionArg $vcfUrl | \
     headStage

--- a/scripts/bcftoolsView.sh
+++ b/scripts/bcftoolsView.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 vcfUrl=$1
 region=$2
-lineNumber=$3
+numLines=$3
 
 regionArg=$region
 if [ ! -z "$region" ]; then
@@ -15,13 +15,13 @@ fi
 
 headStage=cat
 headerArg=$""
-if [ ! -z "$lineNumber" ]; then
+if [ ! -z "$numLines" ]; then
     function headFunc {
-        head -n $lineNumber
+        head -n "$numLines"
     }
     headStage=headFunc
     headerArg="-H" #Don't include header
 fi
 
 bcftools view $headerArg $regionArg $vcfUrl | \
-    headStage
+    $headStage

--- a/scripts/getIdColumns.sh
+++ b/scripts/getIdColumns.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-vcfUrl=$1
-region=$2
-
-bcftools view -r $region $vcfUrl

--- a/src/index.js
+++ b/src/index.js
@@ -528,8 +528,9 @@ router.post('/bcftoolsView', async (ctx) => {
     const params = JSON.parse(ctx.request.body);
 
     const regionStr = params.regions == null ? "" : genRegionsStr(params.regions, ",");
+    const numRecords = params.numRecords == null ? "" : params.numRecords;
     const args = [
-        params.vcfUrl, regionStr, params.numRecords
+        params.vcfUrl, regionStr, numRecords
     ];
 
     await handle(ctx, 'bcftoolsView.sh', args, { ignoreStderr: true });

--- a/src/index.js
+++ b/src/index.js
@@ -527,8 +527,8 @@ router.post('/bcftoolsView', async (ctx) => {
 
     const params = JSON.parse(ctx.request.body);
 
-    const regionStr = params.regions == null ? "" : genRegionsStr(params.regions, ",");
-    const numRecords = params.numRecords == null ? "" : params.numRecords;
+    const regionStr = params.regions == undefined ? "" : genRegionsStr(params.regions, ",");
+    const numRecords = params.numRecords == undefined ? "" : params.numRecords;
     const args = [
         params.vcfUrl, regionStr, numRecords
     ];

--- a/src/index.js
+++ b/src/index.js
@@ -523,16 +523,16 @@ router.post('/clinReport', async (ctx) => {
 
 // oncogene endpoints
 //
-router.post('/getIdColumns', async (ctx) => {
+router.post('/bcftoolsView', async (ctx) => {
 
     const params = JSON.parse(ctx.request.body);
 
     const regionStr = genRegionsStr(params.regions, ",");
     const args = [
-        params.vcfUrl, regionStr
+        params.vcfUrl, regionStr, params.rowNum
     ];
 
-    await handle(ctx, 'getIdColumns.sh', args, { ignoreStderr: true });
+    await handle(ctx, 'bcftoolsView.sh', args, { ignoreStderr: true });
 });
 
 router.post('/checkBamBai', async (ctx) => {

--- a/src/index.js
+++ b/src/index.js
@@ -527,9 +527,9 @@ router.post('/bcftoolsView', async (ctx) => {
 
     const params = JSON.parse(ctx.request.body);
 
-    const regionStr = genRegionsStr(params.regions, ",");
+    const regionStr = params.regions == null ? "" : genRegionsStr(params.regions, ",");
     const args = [
-        params.vcfUrl, regionStr, params.rowNum
+        params.vcfUrl, regionStr, params.numRecords
     ];
 
     await handle(ctx, 'bcftoolsView.sh', args, { ignoreStderr: true });


### PR DESCRIPTION
This change updates a service previously called `getIdColumns.sh` to `bcftoolsView.sh` and adds a small amount of functionality. The previous version of this script simply ran `bcftools view` on a provided region. The updated version still provides the initial functionality, but also adds the ability to pull back a provided number of records without the header field. This script is used only in oncogene currently, but could easily be amended to provide any arguments compatible with the `bcftools view` command, and might be useful in many of our apps going forward. Also avoiding backend bloat by amending this to be a simple wrapper, rather than multiple scripts that do very similar things.