### PR TITLE
Backend changes for gene.iobio 4.11 (gnomAD v4, geneinfo lookup)

### DIFF
--- a/scripts/annotateVariantsV3.sh
+++ b/scripts/annotateVariantsV3.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+vcfUrl=$1
+tbiUrl=$2
+region=$3
+contigStr=$4
+vcfSampleNamesStr=$5
+refFastaFile=$6
+genomeBuildName=$7
+vepCacheDir=$8
+vepREVELFile=$9
+vepPluginDir=${10}
+hgvsNotation=${11}
+getRsId=${12}
+decompose=${13}
+
+# default optional stages to no-op
+subsetStage=cat
+decomposeStage=cat
+
+if [ "$vcfSampleNamesStr" ]; then
+    echo -e "$vcfSampleNamesStr" > samples.txt
+
+    function subsetFunc {
+        vt subset -s samples.txt -
+    }
+
+    subsetStage=subsetFunc
+fi
+
+
+if [ "$decompose" == "true" ]; then
+    function decomposeFunc {
+        vt decompose -s  -
+    }
+
+    decomposeStage=decomposeFunc
+fi
+
+if [ "$genomeBuildName" == "GRCh38" ]; then
+    toml="/gru_data/vcfanno/GRCh38/annotate_variants.toml"
+else
+    toml="/gru_data/vcfanno/GRCh37/annotate_variants.toml"
+fi
+
+custom_lua="/gru_data/vcfanno/custom.lua"
+
+vcfanno="vcfanno --lua $custom_lua $toml /dev/stdin"
+
+echo -e "$contigStr" > contigs.txt
+
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
+
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number"
+
+if [ "$hgvsNotation" == "true" ]; then
+    vepArgs="$vepArgs --hgvs"
+fi
+
+if [ "$getRsId" == "true" ]; then
+    vepArgs="$vepArgs --check_existing"
+fi
+
+if [ "$vepREVELFile" ]; then
+    vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"
+fi
+
+tabixVcfArg=$vcfUrl
+if [ -n "${tbiUrl}" ]; then
+    tabixVcfArg="$vcfUrl##idx##$tbiUrl"
+fi
+
+tabix -h $tabixVcfArg $region | \
+    bcftools annotate -h contigs.txt - | \
+    $subsetStage | \
+    $decomposeStage | \
+    vt normalize -n -r $refFastaFile - | \
+    vep $vepArgs | \
+    $vcfanno

--- a/scripts/freebayesJointCallV3.sh
+++ b/scripts/freebayesJointCallV3.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# TODO: add 'set -u' once we fix unbound variables
+#set -euo pipefail
+set -eo pipefail
+
+alignmentUrls=$1
+alignmentIndices=$2
+region=$3
+refFastaFile=$4
+useSuggestedVariants=$5
+clinvarUrl=$6
+genomeBuildName=$7
+vepREVELFile=$8
+samplesFileStr=${9}
+extraArgs=${10}
+vepCacheDir=${11}
+vepPluginDir=${12}
+decompose=${13}
+contigStr=${14}
+dataDir=${15}
+
+contigFile="contig.txt"
+echo -e "$contigStr" > $contigFile
+
+samplesFile="samples.txt"
+echo -e "$samplesFileStr" > $samplesFile
+
+export REF_CACHE=$dataDir/md5_reference_cache/%2s/%2s/%s
+
+freebayesArgs="-s $samplesFile"
+
+# split alignments by ','
+IFS=','
+read -ra urls <<< "$alignmentUrls"
+read -ra indices <<< "$alignmentIndices"
+for i in "${!urls[@]}"; do
+    url=${urls[$i]}
+    indexUrl=${indices[$i]}
+    alignmentFile=$(mktemp --tmpdir=./)
+
+    if [ -n "${indexUrl}" ]; then
+        samtools view -b -X $url $indexUrl $region > $alignmentFile &
+    else
+        samtools view -b $url $region > $alignmentFile &
+    fi
+
+    freebayesArgs="$freebayesArgs -b $alignmentFile"
+done
+IFS=' '
+
+tabixCommand=''
+if [ "$useSuggestedVariants" == "true" ]; then
+    suggFile="sugg.vcf"
+    tabix -h $clinvarUrl $region | vt view -f "INFO.CLNSIG=~'5|4'" - > $suggFile
+    freebayesArgs="$freebayesArgs -@ $suggFile"
+fi
+
+decomposeStage=''
+if [ "$decompose" == "true" ]; then
+    function decomposeFunc {
+        vt decompose -s  -
+    }
+    decomposeStage=decomposeFunc
+fi
+
+
+if [ "$genomeBuildName" == "GRCh38" ]; then
+    toml="/gru_data/vcfanno/GRCh38/annotate_variants.toml"
+else
+    toml="/gru_data/vcfanno/GRCh37/annotate_variants.toml"
+fi
+
+custom_lua="/gru_data/vcfanno/custom.lua"
+
+vcfanno="vcfanno --lua $custom_lua $toml /dev/stdin"
+
+
+freebayesArgs="$freebayesArgs $extraArgs"
+
+vepBaseArgs="-i STDIN --format vcf --cache --dir_cache $vepCacheDir --offline --vcf -o STDOUT --no_stats --no_escape --sift b --polyphen b --regulatory --fork 4 --merged --fasta $refFastaFile"
+
+vepArgs="$vepBaseArgs --assembly $genomeBuildName --allele_number --hgvs --check_existing"
+
+if [ "$vepREVELFile" ]; then
+    vepArgs="$vepArgs --dir_plugins $vepPluginDir --plugin REVEL,$vepREVELFile"
+fi
+
+wait
+
+# TODO: vt filter -d used to be "Variants called by iobio" when invoked by
+# minion, but for some reason I can't get it to accept more than a single word
+# directly in the bash script
+freebayes -f $refFastaFile $freebayesArgs | \
+    $decomposeStage | \
+    bcftools norm -m - -w 10000 -f $refFastaFile - \ |
+    vt filter -f 'QUAL>1' -t 'PASS' -d 'iobio' - | \
+    bcftools annotate -h $contigFile | \
+    vep $vepArgs | \
+    $vcfanno


### PR DESCRIPTION
1. Expanded variant annotations
Using vcfanno, annotate variants with gnomAD v4 and various pathogenicity scores from CADD, AlphaMissense, Eve, and MutScore. We will also annotate the variants with ClinVar, obviating the need for gene.iobio to make separate requests to retreive and merge clinvar annotatations. See issue https://github.com/iobio/gene.iobio/issues/1059

  - **NOTE: We have decided to phase these annotations, so for this iobio gru release, we will be annotating with gnomAD and ClinVar only. Future releases will consider annotating with AlphaMissense, CADD, Eve, and Mutscore.**

   - We will have 2 new endpoints annotateVariantsV3 and freebayesJointCall

   - This expanded annovar will require significant changes to the gru_data directory. You can find the data directory for testing here: /ssd/gru/tony/gru_data_test
       - new directory vcfanno/
       - delete directory gnomad/ (at a later date)

2. New lookup endpoints for geneinfo service 
   - Provide a more sensible gene search behavior that looks up genes by name first and if no hits, search gene aliases. The current typeahead was clumsy, showing the user a gene name and in parentheses, all gene aliases. See
https://github.com/iobio/gene.iobio/issues/1056

   - Get rid of genes.json, a client-side json object that was used to search genes with type-ahead. This json object and its derived javascript objects (allKnownGenes, allKnownGeneNames) was consuming huge amounts of heap space. By using async requests instead of an in-memory lookup, the heap size was reduced 3 fold when app first loaded (reduced from 188M to 56 M). See https://github.com/iobio/gene.iobio/issues/1065