### PR TITLE
Fix the fallthrough bug cause by 'fi'. This bug causes the GRCh37 tom…

### DIFF
--- a/scripts/getClinvarVariantsV2.sh
+++ b/scripts/getClinvarVariantsV2.sh
@@ -24,8 +24,9 @@ if [ "$gnomadMergeAnnots" ]; then
     
     if [ "$genomeBuildName" == "GRCh38" ]; then
         toml="/gru_data/gnomad/vcfanno_gnomad_3.1_grch38.toml"
+    else
+        toml="/gru_data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
     fi
-    	toml="/gru_data/gnomad/vcfanno_gnomad_2.1_grch37.toml"
 
     function gnomadAnnotFunc {
         # Add the gnomAD INFO fields to the input vcf


### PR DESCRIPTION
…l to be used regardless of the genomeBuildName